### PR TITLE
Fix typo in nds-bootstrap page

### DIFF
--- a/pages/english/nds-bootstrap.html
+++ b/pages/english/nds-bootstrap.html
@@ -32,7 +32,7 @@
 						<hr>
 						Hit <span class="font buttonL"></span>, <span class="font buttonR"></span>, START & SELECT to reset the game.
 						<hr>
-						Hit <span class="font buttonL"></span>, <span class="font buttonR"></span>, <span class="font dpadDOWN"></span> & <span class="font buttonA"></span> to create a NAND dump.
+						Hit <span class="font buttonL"></span>, <span class="font buttonR"></span>, <span class="font dpadDOWN"></span> & <span class="font buttonA"></span> to create a RAM dump.
 					</div>
 
 					<div class="section-title">Cheats</div>


### PR DESCRIPTION
We dump the RAM, not the NAND